### PR TITLE
Fix Run commands to build and start docker images

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@ TL;DR: Using task runner:
 
 
 ```bash
-npm run build-development
-npm run start-development
+npm run build
+npm run start
 ```
 
 


### PR DESCRIPTION
What?
* `build-development` and `start-development` are not defined in `package.json`
* `npm run build` or `npm run start` internally trigger the `build-development` and `start-development` scripts respectively